### PR TITLE
Update OpenJDK to 25, remove blueprint-compiler from manifest

### DIFF
--- a/io.github.cgueret.Scriptorium.json
+++ b/io.github.cgueret.Scriptorium.json
@@ -4,7 +4,7 @@
     "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.openjdk21"
+        "org.freedesktop.Sdk.Extension.openjdk25"
     ],
     "command": "scriptorium",
     "finish-args": [
@@ -73,7 +73,7 @@
                     "name": "openjdk",
                     "buildsystem": "simple",
                     "build-commands": [
-                        "/usr/lib/sdk/openjdk21/install.sh"
+                        "/usr/lib/sdk/openjdk25/install.sh"
                     ]
                 }
             ]


### PR DESCRIPTION
blueprint-compiler is part of the Sdk since v49 and can be removed from the manifest
LanguageTool works fine with newest Java